### PR TITLE
Add swiftlint

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -50,6 +50,7 @@ excluded: # paths to ignore during linting. overridden by `included`.
   - Pods
   - .git
   - ReactiveArchitectureTests
+  - ReactiveArchitectureUITests
 
 line_length:
   - 160

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -1,0 +1,68 @@
+whitelist_rules:
+  - closing_brace
+  - control_statement
+  - custom_rules
+  - cyclomatic_complexity
+  - dynamic_inline
+  - empty_count
+  - empty_parameters
+  - file_length
+  - force_cast
+  - force_try
+  - force_unwrapping
+  - function_body_length
+  - function_parameter_count
+  - leading_whitespace
+  - legacy_cggeometry_functions
+  - legacy_constant
+  - legacy_constructor
+  - legacy_nsgeometry_functions
+  - line_length
+  - mark
+  - nesting
+  - operator_whitespace
+  - private_unit_test
+  - return_arrow_whitespace
+  - statement_position
+  - trailing_newline
+  - trailing_semicolon
+  - type_body_length
+  - type_name
+  - unused_enumerated
+  - valid_ibinspectable
+  - colon
+  - closure_spacing
+  - comma
+  - empty_parentheses_with_trailing_closure
+  - implicit_return
+  - opening_brace
+  - operator_usage_whitespace
+  - redundant_discardable_let
+  - redundant_nil_coalescing
+  - redundant_optional_initialization
+  - redundant_void_return
+  - trailing_comma
+  - unused_closure_parameter
+  - void_return
+  - identifier_name
+
+excluded: # paths to ignore during linting. overridden by `included`.
+  - Pods
+  - .git
+  - ReactiveArchitectureTests
+
+line_length:
+  - 160
+  - 200
+type_body_length:
+  - 300 # warning
+  - 400 # error
+function_body_length:
+  - 60
+  - 120
+identifier_name:
+  max_length:
+    warning: 50
+    error: 60
+  excluded:
+    - id

--- a/ReactiveArchitecture.xcodeproj/project.pbxproj
+++ b/ReactiveArchitecture.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		1D1334FB3221641EA77D4B2E /* Pods_ReactiveArchitectureUITests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3D1F51331460467339977E99 /* Pods_ReactiveArchitectureUITests.framework */; };
 		2197BE45551A5EB5404C15C7 /* Pods_ReactiveArchitecture.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1901FB5F9B5FB6CD6B54A996 /* Pods_ReactiveArchitecture.framework */; };
+		40D78D1B201617E700015AE8 /* Observable+Optional.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40D78D1A201617E700015AE8 /* Observable+Optional.swift */; };
 		850073821FFBC5D300E56A70 /* ProgressCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 850073811FFBC5D300E56A70 /* ProgressCell.swift */; };
 		850073841FFBC81600E56A70 /* MovieViewInfoImpl.swift in Sources */ = {isa = PBXBuildFile; fileRef = 850073831FFBC81600E56A70 /* MovieViewInfoImpl.swift */; };
 		850073871FFBC8B200E56A70 /* ProgressViewInfoImpl.swift in Sources */ = {isa = PBXBuildFile; fileRef = 850073861FFBC8B200E56A70 /* ProgressViewInfoImpl.swift */; };
@@ -126,6 +127,7 @@
 		114D9D4883DF26946500BA99 /* Pods-ReactiveArchitectureTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ReactiveArchitectureTests.release.xcconfig"; path = "Pods/Target Support Files/Pods-ReactiveArchitectureTests/Pods-ReactiveArchitectureTests.release.xcconfig"; sourceTree = "<group>"; };
 		1901FB5F9B5FB6CD6B54A996 /* Pods_ReactiveArchitecture.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_ReactiveArchitecture.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		3D1F51331460467339977E99 /* Pods_ReactiveArchitectureUITests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_ReactiveArchitectureUITests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		40D78D1A201617E700015AE8 /* Observable+Optional.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Observable+Optional.swift"; sourceTree = "<group>"; };
 		5E3CB1998B032BDF098F2870 /* Pods-ReactiveArchitectureUITests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ReactiveArchitectureUITests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-ReactiveArchitectureUITests/Pods-ReactiveArchitectureUITests.debug.xcconfig"; sourceTree = "<group>"; };
 		850073811FFBC5D300E56A70 /* ProgressCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProgressCell.swift; sourceTree = "<group>"; };
 		850073831FFBC81600E56A70 /* MovieViewInfoImpl.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MovieViewInfoImpl.swift; sourceTree = "<group>"; };
@@ -358,6 +360,7 @@
 			children = (
 				8539ECBD1FE9C4B5001D6295 /* ArrayExtension.swift */,
 				8500739720054EB500E56A70 /* ConnectableObservableExtension.swift */,
+				40D78D1A201617E700015AE8 /* Observable+Optional.swift */,
 			);
 			path = extension;
 			sourceTree = "<group>";
@@ -622,6 +625,7 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 85DC74301FBA87CD00BACD4D /* Build configuration list for PBXNativeTarget "ReactiveArchitecture" */;
 			buildPhases = (
+				40D78D192016168300015AE8 /* Swiftlint */,
 				E5E6C8C85977B36AB051C343 /* [CP] Check Pods Manifest.lock */,
 				85DC74041FBA87CD00BACD4D /* Sources */,
 				85DC74051FBA87CD00BACD4D /* Frameworks */,
@@ -777,15 +781,48 @@
 			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-ReactiveArchitecture/Pods-ReactiveArchitecture-resources.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
-		422EFA51F8E066DC1270CA60 /* [CP] Embed Pods Frameworks */ = {
+		40D78D192016168300015AE8 /* Swiftlint */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			inputPaths = (
 			);
+			name = Swiftlint;
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "if which swiftlint >/dev/null; then\n  swiftlint\nelse\n  echo \"warning: SwiftLint not installed, download from https://github.com/realm/SwiftLint\"\nfi";
+		};
+		422EFA51F8E066DC1270CA60 /* [CP] Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+				"${SRCROOT}/Pods/Target Support Files/Pods-ReactiveArchitectureTests/Pods-ReactiveArchitectureTests-frameworks.sh",
+				"${BUILT_PRODUCTS_DIR}/Alamofire/Alamofire.framework",
+				"${BUILT_PRODUCTS_DIR}/AlamofireObjectMapper/AlamofireObjectMapper.framework",
+				"${BUILT_PRODUCTS_DIR}/CocoaLumberjack/CocoaLumberjack.framework",
+				"${BUILT_PRODUCTS_DIR}/ObjectMapper/ObjectMapper.framework",
+				"${BUILT_PRODUCTS_DIR}/RxAlamofire/RxAlamofire.framework",
+				"${BUILT_PRODUCTS_DIR}/RxSwift/RxSwift.framework",
+				"${BUILT_PRODUCTS_DIR}/RxBlocking/RxBlocking.framework",
+				"${BUILT_PRODUCTS_DIR}/RxTest/RxTest.framework",
+				"${BUILT_PRODUCTS_DIR}/SwiftHamcrest/Hamcrest.framework",
+			);
 			name = "[CP] Embed Pods Frameworks";
 			outputPaths = (
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Alamofire.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/AlamofireObjectMapper.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/CocoaLumberjack.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/ObjectMapper.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/RxAlamofire.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/RxSwift.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/RxBlocking.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/RxTest.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Hamcrest.framework",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
@@ -798,9 +835,32 @@
 			files = (
 			);
 			inputPaths = (
+				"${SRCROOT}/Pods/Target Support Files/Pods-ReactiveArchitecture/Pods-ReactiveArchitecture-frameworks.sh",
+				"${BUILT_PRODUCTS_DIR}/Alamofire/Alamofire.framework",
+				"${BUILT_PRODUCTS_DIR}/AlamofireImage/AlamofireImage.framework",
+				"${BUILT_PRODUCTS_DIR}/AlamofireObjectMapper/AlamofireObjectMapper.framework",
+				"${BUILT_PRODUCTS_DIR}/CocoaLumberjack/CocoaLumberjack.framework",
+				"${BUILT_PRODUCTS_DIR}/Dip/Dip.framework",
+				"${BUILT_PRODUCTS_DIR}/Dip-UI/Dip_UI.framework",
+				"${BUILT_PRODUCTS_DIR}/ObjectMapper/ObjectMapper.framework",
+				"${BUILT_PRODUCTS_DIR}/RxAlamofire/RxAlamofire.framework",
+				"${BUILT_PRODUCTS_DIR}/RxCocoa/RxCocoa.framework",
+				"${BUILT_PRODUCTS_DIR}/RxSwift/RxSwift.framework",
+				"${BUILT_PRODUCTS_DIR}/Toast-Swift/Toast_Swift.framework",
 			);
 			name = "[CP] Embed Pods Frameworks";
 			outputPaths = (
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Alamofire.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/AlamofireImage.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/AlamofireObjectMapper.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/CocoaLumberjack.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Dip.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Dip_UI.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/ObjectMapper.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/RxAlamofire.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/RxCocoa.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/RxSwift.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Toast_Swift.framework",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
@@ -843,13 +903,16 @@
 			files = (
 			);
 			inputPaths = (
+				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"${PODS_ROOT}/Manifest.lock",
 			);
 			name = "[CP] Check Pods Manifest.lock";
 			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-ReactiveArchitectureUITests-checkManifestLockResult.txt",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n";
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
 			showEnvVarsInLog = 0;
 		};
 		AE5D6D5AB5270BB54948A33C /* [CP] Check Pods Manifest.lock */ = {
@@ -858,13 +921,16 @@
 			files = (
 			);
 			inputPaths = (
+				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"${PODS_ROOT}/Manifest.lock",
 			);
 			name = "[CP] Check Pods Manifest.lock";
 			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-ReactiveArchitectureTests-checkManifestLockResult.txt",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n";
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
 			showEnvVarsInLog = 0;
 		};
 		AFBFBF5A463C897D17946769 /* [CP] Copy Pods Resources */ = {
@@ -888,13 +954,16 @@
 			files = (
 			);
 			inputPaths = (
+				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"${PODS_ROOT}/Manifest.lock",
 			);
 			name = "[CP] Check Pods Manifest.lock";
 			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-ReactiveArchitecture-checkManifestLockResult.txt",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n";
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
 			showEnvVarsInLog = 0;
 		};
 /* End PBXShellScriptBuildPhase section */
@@ -936,6 +1005,7 @@
 				8500738A1FFD165C00E56A70 /* NowPlayingInteractorImpl.swift in Sources */,
 				85ED0DE11FCF3A0A00793B91 /* APIError.swift in Sources */,
 				85EC961B1FE313CE002B9B42 /* ScrollEvent.swift in Sources */,
+				40D78D1B201617E700015AE8 /* Observable+Optional.swift in Sources */,
 				8500738E1FFD1F5600E56A70 /* ScrollAction.swift in Sources */,
 				850073841FFBC81600E56A70 /* MovieViewInfoImpl.swift in Sources */,
 				8521CE641FD83571002A01A2 /* NowPlayingInfo.swift in Sources */,

--- a/ReactiveArchitecture.xcodeproj/project.pbxproj
+++ b/ReactiveArchitecture.xcodeproj/project.pbxproj
@@ -10,6 +10,7 @@
 		1D1334FB3221641EA77D4B2E /* Pods_ReactiveArchitectureUITests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3D1F51331460467339977E99 /* Pods_ReactiveArchitectureUITests.framework */; };
 		2197BE45551A5EB5404C15C7 /* Pods_ReactiveArchitecture.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1901FB5F9B5FB6CD6B54A996 /* Pods_ReactiveArchitecture.framework */; };
 		40D78D1B201617E700015AE8 /* Observable+Optional.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40D78D1A201617E700015AE8 /* Observable+Optional.swift */; };
+		40D78D1C2016250B00015AE8 /* Observable+Optional.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40D78D1A201617E700015AE8 /* Observable+Optional.swift */; };
 		850073821FFBC5D300E56A70 /* ProgressCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 850073811FFBC5D300E56A70 /* ProgressCell.swift */; };
 		850073841FFBC81600E56A70 /* MovieViewInfoImpl.swift in Sources */ = {isa = PBXBuildFile; fileRef = 850073831FFBC81600E56A70 /* MovieViewInfoImpl.swift */; };
 		850073871FFBC8B200E56A70 /* ProgressViewInfoImpl.swift in Sources */ = {isa = PBXBuildFile; fileRef = 850073861FFBC8B200E56A70 /* ProgressViewInfoImpl.swift */; };
@@ -1025,6 +1026,7 @@
 				850073C0200A8F3800E56A70 /* UiModel.swift in Sources */,
 				850073C1200A8F3800E56A70 /* MovieViewInfo.swift in Sources */,
 				850073C2200A8F3800E56A70 /* MovieViewInfoImpl.swift in Sources */,
+				40D78D1C2016250B00015AE8 /* Observable+Optional.swift in Sources */,
 				850073C3200A8F3800E56A70 /* ProgressViewInfoImpl.swift in Sources */,
 				850073BD200A8F1700E56A70 /* AdapterCommandType.swift in Sources */,
 				850073BB200A8C2700E56A70 /* UiEvent.swift in Sources */,

--- a/ReactiveArchitecture/Classes/core/AppDelegate/AppDelegate.swift
+++ b/ReactiveArchitecture/Classes/core/AppDelegate/AppDelegate.swift
@@ -67,10 +67,9 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         //DDLog.add(DDASLLogger.sharedInstance) // ASL = Apple System Logs
         
         let fileLogger: DDFileLogger = DDFileLogger() // File Logger
-        fileLogger.rollingFrequency = TimeInterval(60*60*24)  // 24 hours
+        fileLogger.rollingFrequency = TimeInterval(60 * 60 * 24)  // 24 hours
         fileLogger.logFileManager.maximumNumberOfLogFiles = 7
         DDLog.add(fileLogger)
     }
 
 }
-

--- a/ReactiveArchitecture/Classes/core/AppDelegate/AppDelegate.swift
+++ b/ReactiveArchitecture/Classes/core/AppDelegate/AppDelegate.swift
@@ -36,29 +36,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         
         return true
     }
-
-    func applicationWillResignActive(_ application: UIApplication) {
-        // Sent when the application is about to move from active to inactive state. This can occur for certain types of temporary interruptions (such as an incoming phone call or SMS message) or when the user quits the application and it begins the transition to the background state.
-        // Use this method to pause ongoing tasks, disable timers, and invalidate graphics rendering callbacks. Games should use this method to pause the game.
-    }
-
-    func applicationDidEnterBackground(_ application: UIApplication) {
-        // Use this method to release shared resources, save user data, invalidate timers, and store enough application state information to restore your application to its current state in case it is terminated later.
-        // If your application supports background execution, this method is called instead of applicationWillTerminate: when the user quits.
-    }
-
-    func applicationWillEnterForeground(_ application: UIApplication) {
-        // Called as part of the transition from the background to the active state; here you can undo many of the changes made on entering the background.
-    }
-
-    func applicationDidBecomeActive(_ application: UIApplication) {
-        // Restart any tasks that were paused (or not yet started) while the application was inactive. If the application was previously in the background, optionally refresh the user interface.
-    }
-
-    func applicationWillTerminate(_ application: UIApplication) {
-        // Called when the application is about to terminate. Save data if appropriate. See also applicationDidEnterBackground:.
-    }
-
+    
     /**
      * Setup the Lumberjack logging.
      */

--- a/ReactiveArchitecture/Classes/core/dip/AppDelegateModule.swift
+++ b/ReactiveArchitecture/Classes/core/dip/AppDelegateModule.swift
@@ -36,7 +36,7 @@ extension DependencyContainer {
             //
             //App Singleton
             //
-            container.register(.singleton) { ServiceApiImpl(baseUrl: "https://api.themoviedb.org/3/movie") as ServiceApi}
+            container.register(.singleton) { ServiceApiImpl(baseUrl: "https://api.themoviedb.org/3/movie") as ServiceApi }
             container.register(.singleton) {
                 serviceApi in ServiceControllerImpl(serviceApi: serviceApi,
                                                     apiKey: NSLocalizedString("api_key", comment: ""),
@@ -47,7 +47,7 @@ extension DependencyContainer {
             //
             // VC Singleton
             //
-            container.register {serviceController in NowPlayingViewModel(serviceController: serviceController) as NowPlayingViewModel}
+            container.register { serviceController in NowPlayingViewModel(serviceController: serviceController) as NowPlayingViewModel }
             
             //
             // Inject View Controllers
@@ -63,5 +63,3 @@ extension DependencyContainer {
 }
 
 extension NowPlayingViewController: StoryboardInstantiatable { }
-
-

--- a/ReactiveArchitecture/Classes/core/error/APIError.swift
+++ b/ReactiveArchitecture/Classes/core/error/APIError.swift
@@ -28,7 +28,9 @@ import Foundation
 
 public struct APIError: Error {
     
-    /// The error code. In most cases, this is an error code returned by the API server. However, if the error code begins with "CLI" then it is a client-side error, e.g. something that prevented even getting a response from the server (such as, 'network not available').
+    /// The error code. In most cases, this is an error code returned by the API server.
+    /// However, if the error code begins with "CLI" then it is a client-side error,
+    /// e.g. something that prevented even getting a response from the server (such as, 'network not available').
     
     let code: String
     
@@ -38,7 +40,8 @@ public struct APIError: Error {
     let message: String
     
     
-    /// A non-nil value indicates a client-side error (some error condition that happens on the client side, as opposed to being returned from the API server, e.g. 'network not available'.
+    /// A non-nil value indicates a client-side error (some error condition that happens on the client side,
+    /// as opposed to being returned from the API server, e.g. 'network not available'.
     
     let underlyingError: NSError?
     
@@ -48,13 +51,15 @@ public struct APIError: Error {
     init(code: String?, message: String?) {
         self.code = code ?? "UNK0001" // copy what Go SDK does
         self.message = message ?? "unknown error"
-        // FIXME: Mason 2016-03-06: the Go SDK has one more field, messageArgs, which is used to compose the actual message string, but I haven't yet had time to make that work. (See: api_error.go)
+        // FIXME: Mason 2016-03-06: the Go SDK has one more field, messageArgs, which is used to compose the actual
+        /// message string, but I haven't yet had time to make that work. (See: api_error.go)
         
         self.underlyingError = nil
     }
     
     
-    /// Init an error for a local client-side error. Usually this would be the NSError reported by NSURLSession, e.g. network connection not available.
+    /// Init an error for a local client-side error. Usually this would be the NSError reported by NSURLSession,
+    /// e.g. network connection not available.
     
     init(underlyingError: NSError) {
         self.underlyingError = underlyingError

--- a/ReactiveArchitecture/Classes/core/error/APIError.swift
+++ b/ReactiveArchitecture/Classes/core/error/APIError.swift
@@ -26,7 +26,7 @@
 
 import Foundation
 
-public struct APIError : Error {
+public struct APIError: Error {
     
     /// The error code. In most cases, this is an error code returned by the API server. However, if the error code begins with "CLI" then it is a client-side error, e.g. something that prevented even getting a response from the server (such as, 'network not available').
     
@@ -46,7 +46,7 @@ public struct APIError : Error {
     /// Init an error the normal way, for an error condition returned by the API server.
     
     init(code: String?, message: String?) {
-        self.code    = code ?? "UNK0001" // copy what Go SDK does
+        self.code = code ?? "UNK0001" // copy what Go SDK does
         self.message = message ?? "unknown error"
         // FIXME: Mason 2016-03-06: the Go SDK has one more field, messageArgs, which is used to compose the actual message string, but I haven't yet had time to make that work. (See: api_error.go)
         

--- a/ReactiveArchitecture/Classes/core/error/AppError.swift
+++ b/ReactiveArchitecture/Classes/core/error/AppError.swift
@@ -26,5 +26,5 @@ import Foundation
  Custom Error
  */
 public enum AppError: Error {
-    case RuntimeError(String)
+    case runtimeError(String)
 }

--- a/ReactiveArchitecture/Classes/core/error/AppError.swift
+++ b/ReactiveArchitecture/Classes/core/error/AppError.swift
@@ -25,7 +25,6 @@ import Foundation
 /**
  Custom Error
  */
-public enum AppError : Error {
+public enum AppError: Error {
     case RuntimeError(String)
 }
-

--- a/ReactiveArchitecture/Classes/core/extension/ArrayExtension.swift
+++ b/ReactiveArchitecture/Classes/core/extension/ArrayExtension.swift
@@ -27,7 +27,8 @@ extension Array {
     /**
      Remove an {@linke:Element} from the array.
      
-     Note - make sure the Element works with AnyObject otherwise the remove won't work. Ever. https://stackoverflow.com/questions/47897028/how-to-remove-a-protocol-from-array/47915561#47915561
+     Note - make sure the Element works with AnyObject otherwise the remove won't work. Ever.
+     https://stackoverflow.com/questions/47897028/how-to-remove-a-protocol-from-array/47915561#47915561
      
      Parameters: element - element to remove
      Returns: true when deleted, false otherwise.

--- a/ReactiveArchitecture/Classes/core/extension/ArrayExtension.swift
+++ b/ReactiveArchitecture/Classes/core/extension/ArrayExtension.swift
@@ -33,13 +33,12 @@ extension Array {
      Returns: true when deleted, false otherwise.
      */
     mutating func removeObject(element: Element) {
-        guard let index = index(where: { $0 as AnyObject === element as AnyObject}) else { return }
+        guard let index = index(where: { $0 as AnyObject === element as AnyObject }) else { return }
         remove(at: index)
     }
     
     func indexOf(element: Element) -> Int {
-        guard let index = index(where: { $0 as AnyObject === element as AnyObject}) else { return -1 }
+        guard let index = index(where: { $0 as AnyObject === element as AnyObject }) else { return -1 }
         return index
     }
 }
-

--- a/ReactiveArchitecture/Classes/core/extension/ConnectableObservableExtension.swift
+++ b/ReactiveArchitecture/Classes/core/extension/ConnectableObservableExtension.swift
@@ -27,7 +27,7 @@ import RxSwift
 extension ConnectableObservableType {
     func autoconnect() -> Observable<E> {
         return Observable.create { observer in
-            return self.do(onSubscribe: {
+            self.do(onSubscribe: {
                 _ = self.connect()
             }).subscribe { (event: Event<Self.E>) in
                 switch event {

--- a/ReactiveArchitecture/Classes/core/extension/Observable+Optional.swift
+++ b/ReactiveArchitecture/Classes/core/extension/Observable+Optional.swift
@@ -1,0 +1,30 @@
+//
+//  Observable+Optional.swift
+//  ReactiveArchitecture
+//
+//  Created by Maximilian Clarke on 22/1/18.
+//  Copyright © 2018 leonardis. All rights reserved.
+//
+
+import Foundation
+import RxSwift
+
+// From https://gist.github.com/alskipp/e71f014c8f8a9aa12b8d8f8053b67d72
+
+protocol OptionalType {
+    associatedtype Wrapped
+    
+    var optional: Wrapped? { get }
+}
+
+extension Optional: OptionalType {
+    public var optional: Wrapped? { return self }
+}
+
+extension Observable where Element: OptionalType {
+    func ignoreNil() -> Observable<Element.Wrapped> {
+        return flatMap { value -> Observable<Element.Wrapped> in
+            value.optional.map { .just($0) } ?? .empty()
+        }
+    }
+}

--- a/ReactiveArchitecture/Classes/nowplaying/controller/ServiceControllerImpl.swift
+++ b/ReactiveArchitecture/Classes/nowplaying/controller/ServiceControllerImpl.swift
@@ -26,7 +26,7 @@ import CocoaLumberjack
 /**
  * Implementation of {@link ServiceController}.
  */
-class ServiceControllerImpl : ServiceController {
+class ServiceControllerImpl: ServiceController {
     var serviceApi: ServiceApi
     var apiKey: String
     var imageUrlPath: String
@@ -45,9 +45,9 @@ class ServiceControllerImpl : ServiceController {
     }
 
     func getNowPlaying(pageNumber: Int) -> Observable<NowPlayingInfo> {
-        DDLogInfo("Thread name: " + Thread.current.debugDescription + " Get NowPlaying for Page #" + pageNumber.description);
+        DDLogInfo("Thread name: " + Thread.current.debugDescription + " Get NowPlaying for Page #" + pageNumber.description)
        
-        var mapToSend:Dictionary<String, Int> = [String: Int]()
+        var mapToSend: Dictionary<String, Int> = [String: Int]()
         mapToSend["page"] = pageNumber
         
         /*
@@ -55,8 +55,8 @@ class ServiceControllerImpl : ServiceController {
          internal business response on computation thread. Return observable.
          */
         return serviceApi.nowPlaying(apiKey: apiKey, query: mapToSend)
-            .flatMap{ (serviceResponse: ServiceResponse) -> Observable<NowPlayingInfo> in
-                return TranslateNowPlayingSubscriptionFunc.init(imageUrlPath: self.imageUrlPath).apply(serviceResonse: serviceResponse)
+            .flatMap { (serviceResponse: ServiceResponse) -> Observable<NowPlayingInfo> in
+                TranslateNowPlayingSubscriptionFunc.init(imageUrlPath: self.imageUrlPath).apply(serviceResonse: serviceResponse)
             }
             .do(onError: { (error: Error) in
                 DDLogError("Failed to get data from service. " + error.localizedDescription)
@@ -78,7 +78,7 @@ class ServiceControllerImpl : ServiceController {
     */
     public class TranslateNowPlayingSubscriptionFunc {
         private let dateFormatter = DateFormatter()
-        private let imageUrlPath:String
+        private let imageUrlPath: String
         
         init(imageUrlPath: String) {
             self.imageUrlPath = imageUrlPath
@@ -91,7 +91,7 @@ class ServiceControllerImpl : ServiceController {
             
             var movieInfoList = Array<MovieInfo>()
             
-            for i:Int in 0 ... (serviceResonse.results!.count - 1) {
+            for i: Int in 0 ... (serviceResonse.results!.count - 1) {
                 let movieInfo: MovieInfo = MovieInfoImpl.init(
                     pictureUrl: imageUrlPath + serviceResonse.results![i].poster_path!,
                     title: serviceResonse.results![i].title!,

--- a/ReactiveArchitecture/Classes/nowplaying/controller/ServiceControllerImpl.swift
+++ b/ReactiveArchitecture/Classes/nowplaying/controller/ServiceControllerImpl.swift
@@ -91,19 +91,23 @@ class ServiceControllerImpl: ServiceController {
             
             var movieInfoList = Array<MovieInfo>()
             
-            for i: Int in 0 ... (serviceResonse.results!.count - 1) {
+            for i: Int in 0 ... (serviceResonse.results.count - 1) {
+                guard let releaseDate = dateFormatter.date(from: serviceResonse.results[i].releaseDate) else {
+                    continue
+                }
+                
                 let movieInfo: MovieInfo = MovieInfoImpl.init(
-                    pictureUrl: imageUrlPath + serviceResonse.results![i].posterPath!,
-                    title: serviceResonse.results![i].title!,
-                    releaseDate: dateFormatter.date(from: serviceResonse.results![i].releaseDate!)!,
-                    rating: serviceResonse.results![i].voteAverage!)
+                    pictureUrl: imageUrlPath + serviceResonse.results[i].posterPath,
+                    title: serviceResonse.results[i].title,
+                    releaseDate: releaseDate,
+                    rating: serviceResonse.results[i].voteAverage)
                 
                 movieInfoList.append(movieInfo)
             }
     
             return Observable.just(NowPlayingInfoImpl.init(movieInfoList: movieInfoList,
-                                                           pageNumber: serviceResonse.page!,
-                                                           totalPageNumber: serviceResonse.totalPages!))
+                                                           pageNumber: serviceResonse.page,
+                                                           totalPageNumber: serviceResonse.totalPages))
         }
         
     }

--- a/ReactiveArchitecture/Classes/nowplaying/controller/ServiceControllerImpl.swift
+++ b/ReactiveArchitecture/Classes/nowplaying/controller/ServiceControllerImpl.swift
@@ -93,17 +93,17 @@ class ServiceControllerImpl: ServiceController {
             
             for i: Int in 0 ... (serviceResonse.results!.count - 1) {
                 let movieInfo: MovieInfo = MovieInfoImpl.init(
-                    pictureUrl: imageUrlPath + serviceResonse.results![i].poster_path!,
+                    pictureUrl: imageUrlPath + serviceResonse.results![i].posterPath!,
                     title: serviceResonse.results![i].title!,
-                    releaseDate: dateFormatter.date(from: serviceResonse.results![i].release_date!)!,
-                    rating: serviceResonse.results![i].vote_average!)
+                    releaseDate: dateFormatter.date(from: serviceResonse.results![i].releaseDate!)!,
+                    rating: serviceResonse.results![i].voteAverage!)
                 
                 movieInfoList.append(movieInfo)
             }
     
             return Observable.just(NowPlayingInfoImpl.init(movieInfoList: movieInfoList,
                                                            pageNumber: serviceResonse.page!,
-                                                           totalPageNumber: serviceResonse.total_pages!))
+                                                           totalPageNumber: serviceResonse.totalPages!))
         }
         
     }

--- a/ReactiveArchitecture/Classes/nowplaying/interactor/NowPlayingInteractor .swift
+++ b/ReactiveArchitecture/Classes/nowplaying/interactor/NowPlayingInteractor .swift
@@ -9,6 +9,6 @@
 import Foundation
 import RxSwift
 
-protocol NowPlayingInteractor : class {
+protocol NowPlayingInteractor: class {
     func processAction(actions: Observable<Action>) -> Observable<Result>
 }

--- a/ReactiveArchitecture/Classes/nowplaying/interactor/NowPlayingInteractorImpl.swift
+++ b/ReactiveArchitecture/Classes/nowplaying/interactor/NowPlayingInteractorImpl.swift
@@ -32,7 +32,7 @@ class NowPlayingInteractorImpl: NowPlayingInteractor {
     fileprivate var delayScheduler: SchedulerType = ConcurrentDispatchQueueScheduler(queue: DispatchQueue.global())
     private let serviceController: ServiceController
     //becuase we init a self in a closure this can't be a let or w/o?
-    private var transformActionToResult: ObservableTransformer<ScrollAction, ScrollResult>?
+    private var transformActionToResult: ObservableTransformer<ScrollAction, ScrollResult>!
 
     /**
      Create class for test.
@@ -96,7 +96,7 @@ class NowPlayingInteractorImpl: NowPlayingInteractor {
                 DDLogInfo("Thread name: " + Thread.current.description + " Translate Actions into ScrollActions.")
                 return Observable.just(action)
             }
-            .compose(self.transformActionToResult!)
+            .compose(self.transformActionToResult)
             .flatMap { (scrollResult: ScrollResult) -> Observable<Result> in
                 Observable.just(scrollResult as Result)
             }

--- a/ReactiveArchitecture/Classes/nowplaying/interactor/NowPlayingInteractorImpl.swift
+++ b/ReactiveArchitecture/Classes/nowplaying/interactor/NowPlayingInteractorImpl.swift
@@ -30,7 +30,7 @@ import CocoaLumberjack
  */
 class NowPlayingInteractorImpl: NowPlayingInteractor {
     fileprivate var delayScheduler: SchedulerType = ConcurrentDispatchQueueScheduler(queue: DispatchQueue.global())
-    private let serviceController:ServiceController
+    private let serviceController: ServiceController
     //becuase we init a self in a closure this can't be a let or w/o?
     private var transformActionToResult: ObservableTransformer<ScrollAction, ScrollResult>?
 
@@ -53,12 +53,12 @@ class NowPlayingInteractorImpl: NowPlayingInteractor {
         self.serviceController = serviceController
         
         transformActionToResult = ObservableTransformer<ScrollAction, ScrollResult> { observable in
-            return observable.flatMap{ (scrollAction: ScrollAction) -> Observable<ScrollResult> in                            
+            observable.flatMap { (scrollAction: ScrollAction) -> Observable<ScrollResult> in                            
                 DDLogInfo("Thread name: " + Thread.current.debugDescription + " Load Data, return ScrollResult.")
                 
-                let pageNumberObservable : Observable<Int> = Observable.just(scrollAction.getPageNumber());
+                let pageNumberObservable: Observable<Int> = Observable.just(scrollAction.getPageNumber())
                 
-                let sedrviceControllerObservable : Observable<Array<MovieInfo>> =
+                let sedrviceControllerObservable: Observable<Array<MovieInfo>> =
                     self.serviceController.getNowPlaying(pageNumber: scrollAction.getPageNumber())
                         //Delay for 3 seconds to show spinner on screen.
                         .delay(3, scheduler: self.delayScheduler)
@@ -75,8 +75,8 @@ class NowPlayingInteractorImpl: NowPlayingInteractor {
                         return ScrollResult.sucess(pageNumber: pageNumber, result: movieInfos)
                     }
                     //RxJava - onErrorReturn
-                    .catchError{ (error: Error) -> Observable<ScrollResult> in
-                        return Observable.just(ScrollResult.failure(pageNumber: scrollAction.getPageNumber(), error: error))
+                    .catchError { (error: Error) -> Observable<ScrollResult> in
+                        Observable.just(ScrollResult.failure(pageNumber: scrollAction.getPageNumber(), error: error))
                     }
                     .startWith(ScrollResult.inFlight(pageNumber: scrollAction.getPageNumber()))
                 }
@@ -90,13 +90,13 @@ class NowPlayingInteractorImpl: NowPlayingInteractor {
      */
     func processAction(actions: Observable<Action>) -> Observable<Result> {
         return actions
-            .flatMap{ (action: Action) -> Observable<ScrollAction> in
+            .flatMap { (action: Action) -> Observable<ScrollAction> in
                 DDLogInfo("Thread name: " + Thread.current.description + " Translate Actions into ScrollActions.")
-                return Observable.just(action as! ScrollAction);
+                return Observable.just(action as! ScrollAction)
             }
             .compose(self.transformActionToResult!)
-            .flatMap{ (scrollResult: ScrollResult) -> Observable<Result> in
-                return Observable.just(scrollResult as Result)
+            .flatMap { (scrollResult: ScrollResult) -> Observable<Result> in
+                Observable.just(scrollResult as Result)
             }
     }
 

--- a/ReactiveArchitecture/Classes/nowplaying/interactor/NowPlayingInteractorImpl.swift
+++ b/ReactiveArchitecture/Classes/nowplaying/interactor/NowPlayingInteractorImpl.swift
@@ -90,9 +90,11 @@ class NowPlayingInteractorImpl: NowPlayingInteractor {
      */
     func processAction(actions: Observable<Action>) -> Observable<Result> {
         return actions
-            .flatMap { (action: Action) -> Observable<ScrollAction> in
+            .map { $0 as? ScrollAction }
+            .ignoreNil()
+            .flatMap { action -> Observable<ScrollAction> in
                 DDLogInfo("Thread name: " + Thread.current.description + " Translate Actions into ScrollActions.")
-                return Observable.just(action as! ScrollAction)
+                return Observable.just(action)
             }
             .compose(self.transformActionToResult!)
             .flatMap { (scrollResult: ScrollResult) -> Observable<Result> in

--- a/ReactiveArchitecture/Classes/nowplaying/model/AdapterCommandType.swift
+++ b/ReactiveArchitecture/Classes/nowplaying/model/AdapterCommandType.swift
@@ -27,7 +27,7 @@ import Foundation
  * Command Types.
  */
 enum AdapterCommandType {
-    case DO_NOTHING
-    case ADD_DATA
-    case SHOW_IN_PROGRESS
+    case doNothing
+    case addData
+    case showInProgress
 }

--- a/ReactiveArchitecture/Classes/nowplaying/model/MovieInfoImpl.swift
+++ b/ReactiveArchitecture/Classes/nowplaying/model/MovieInfoImpl.swift
@@ -24,10 +24,10 @@
 import Foundation
 
 class MovieInfoImpl: MovieInfo {
-    private var pictureUrl:String
-    private var title:String
-    private var releaseDate:Date
-    private var rating:Double
+    private var pictureUrl: String
+    private var title: String
+    private var releaseDate: Date
+    private var rating: Double
     
     /**
      * Constructor.
@@ -37,7 +37,7 @@ class MovieInfoImpl: MovieInfo {
      * Parameter rating:
      */
     init(pictureUrl: String, title: String, releaseDate: Date, rating: Double) {
-        self.pictureUrl = pictureUrl;
+        self.pictureUrl = pictureUrl
         self.title = title
         self.releaseDate = releaseDate
         self.rating = rating

--- a/ReactiveArchitecture/Classes/nowplaying/model/action/Action.swift
+++ b/ReactiveArchitecture/Classes/nowplaying/model/action/Action.swift
@@ -26,6 +26,6 @@ import Foundation
 /**
  * Internal representation of {@link com.example.reactivearchitecture.model.event.UiEvent}.
  */
-protocol Action : class {
+protocol Action: class {
     
 }

--- a/ReactiveArchitecture/Classes/nowplaying/model/action/ScrollAction.swift
+++ b/ReactiveArchitecture/Classes/nowplaying/model/action/ScrollAction.swift
@@ -26,8 +26,8 @@ import Foundation
 /**
  * Internal representation of {@link com.example.reactivearchitecture.model.event.ScrollEvent}.
  */
-class ScrollAction : Action {
-    private var pageNumber:Int
+class ScrollAction: Action {
+    private var pageNumber: Int
     
     init(pageNumber: Int) {
         self.pageNumber = pageNumber

--- a/ReactiveArchitecture/Classes/nowplaying/model/event/ScrollEvent.swift
+++ b/ReactiveArchitecture/Classes/nowplaying/model/event/ScrollEvent.swift
@@ -23,8 +23,8 @@
 
 import Foundation
 
-class ScrollEvent : UiEvent {
-    public private(set) var pageNumber:Int
+class ScrollEvent: UiEvent {
+    public private(set) var pageNumber: Int
     
     init(pageNumber: Int) {
         self.pageNumber = pageNumber

--- a/ReactiveArchitecture/Classes/nowplaying/model/result/Result.swift
+++ b/ReactiveArchitecture/Classes/nowplaying/model/result/Result.swift
@@ -18,7 +18,7 @@ protocol Result: class {
 }
 
 enum ResultType {
-    case IN_FLIGHT
-    case SUCCESS
-    case FAILURE
+    case inFlight
+    case success
+    case failure
 }

--- a/ReactiveArchitecture/Classes/nowplaying/model/result/Result.swift
+++ b/ReactiveArchitecture/Classes/nowplaying/model/result/Result.swift
@@ -11,7 +11,7 @@ import Foundation
 /**
  * Base class for results from asynchronous actions.
  */
-protocol Result : class {
+protocol Result: class {
     
     func getType() -> ResultType
     

--- a/ReactiveArchitecture/Classes/nowplaying/model/result/ScrollResult.swift
+++ b/ReactiveArchitecture/Classes/nowplaying/model/result/ScrollResult.swift
@@ -40,7 +40,7 @@ class ScrollResult: Result {
                                  error: nil)
     }
 
-    public static func sucess(pageNumber: Int, result : Array<MovieInfo>) -> ScrollResult {
+    public static func sucess(pageNumber: Int, result: Array<MovieInfo>) -> ScrollResult {
         return ScrollResult.init(resultType: ResultType.SUCCESS,
                                  isSuccessful: true,
                                  isLoading: false,

--- a/ReactiveArchitecture/Classes/nowplaying/model/result/ScrollResult.swift
+++ b/ReactiveArchitecture/Classes/nowplaying/model/result/ScrollResult.swift
@@ -32,7 +32,7 @@ class ScrollResult: Result {
     private(set) var error: Error?
     
     public static func inFlight(pageNumber: Int) -> ScrollResult {
-        return ScrollResult.init(resultType: ResultType.IN_FLIGHT,
+        return ScrollResult.init(resultType: ResultType.inFlight,
                                  isSuccessful: false,
                                  isLoading: true,
                                  pageNumber: pageNumber,
@@ -41,7 +41,7 @@ class ScrollResult: Result {
     }
 
     public static func sucess(pageNumber: Int, result: Array<MovieInfo>) -> ScrollResult {
-        return ScrollResult.init(resultType: ResultType.SUCCESS,
+        return ScrollResult.init(resultType: ResultType.success,
                                  isSuccessful: true,
                                  isLoading: false,
                                  pageNumber: pageNumber,
@@ -50,7 +50,7 @@ class ScrollResult: Result {
     }
     
     public static func failure(pageNumber: Int, error: Error) -> ScrollResult {
-        return ScrollResult.init(resultType: ResultType.FAILURE,
+        return ScrollResult.init(resultType: ResultType.failure,
                                  isSuccessful: false,
                                  isLoading: false,
                                  pageNumber: pageNumber,

--- a/ReactiveArchitecture/Classes/nowplaying/model/uimodel/UiModel.swift
+++ b/ReactiveArchitecture/Classes/nowplaying/model/uimodel/UiModel.swift
@@ -48,7 +48,7 @@ class UiModel {
                             enableScrollListener: false,
                             currentList: Array(),
                             resultList: nil,
-                            adapterCommandType: AdapterCommandType.DO_NOTHING)
+                            adapterCommandType: AdapterCommandType.doNothing)
     }
     
     /**
@@ -65,7 +65,7 @@ class UiModel {
                             enableScrollListener: true,
                             currentList: fullList,
                             resultList: valuesToAdd,
-                            adapterCommandType: AdapterCommandType.ADD_DATA)
+                            adapterCommandType: AdapterCommandType.addData)
     }
     
     /**
@@ -82,7 +82,7 @@ class UiModel {
                             enableScrollListener: false,
                             currentList: fullList,
                             resultList: nil,
-                            adapterCommandType: AdapterCommandType.DO_NOTHING)
+                            adapterCommandType: AdapterCommandType.doNothing)
     }
     
     /**
@@ -99,7 +99,7 @@ class UiModel {
                             enableScrollListener: false,
                             currentList: fullList,
                             resultList: nil,
-                            adapterCommandType: firstTimeLoad ? AdapterCommandType.DO_NOTHING : AdapterCommandType.SHOW_IN_PROGRESS)
+                            adapterCommandType: firstTimeLoad ? AdapterCommandType.doNothing : AdapterCommandType.showInProgress)
     }
 
     /**
@@ -112,7 +112,9 @@ class UiModel {
         return arrayCopy
     }
 
-    fileprivate init(firstTimeLoad: Bool, failureMsg: String?, pageNumber: Int, enableScrollListener: Bool, currentList: Array<MovieViewInfo>?, resultList: Array<MovieViewInfo>?, adapterCommandType: AdapterCommandType) {
+    fileprivate init(firstTimeLoad: Bool, failureMsg: String?, pageNumber: Int, enableScrollListener: Bool,
+                     currentList: Array<MovieViewInfo>?, resultList: Array<MovieViewInfo>?,
+                     adapterCommandType: AdapterCommandType) {
         self.firstTimeLoad = firstTimeLoad
         self.failureMsg = failureMsg
         self.pageNumber = pageNumber
@@ -159,7 +161,7 @@ class UiModel {
             self.firstTimeLoad = false
             self.pageNumber = 0
             self.enableScrollListener = false
-            self.adapterCommandType = AdapterCommandType.DO_NOTHING
+            self.adapterCommandType = AdapterCommandType.doNothing
         }
         
         /**
@@ -167,8 +169,8 @@ class UiModel {
          * @return new {@link UiModel}.
          */
         func createUiModel() -> UiModel {
-            if (currentList == nil) {
-                if (uiModel == nil) {
+            if currentList == nil {
+                if uiModel == nil {
                     currentList = Array<MovieViewInfo>()
                 } else {
                     //shallow copy

--- a/ReactiveArchitecture/Classes/nowplaying/model/uimodel/UiModel.swift
+++ b/ReactiveArchitecture/Classes/nowplaying/model/uimodel/UiModel.swift
@@ -1,4 +1,4 @@
- //
+//
 //  UiModel.swift
 //  ReactiveArchitecture
 //
@@ -28,13 +28,13 @@ import Foundation
   * Note - fields in this class should be immutable for "Scan" safety.
   */
 class UiModel {
-    private(set) var firstTimeLoad:Bool
-    private(set) var failureMsg:String?
-    private(set) var pageNumber:Int
-    private(set) var enableScrollListener:Bool
-    private var currentList:Array<MovieViewInfo>?
-    private(set) var resultList:Array<MovieViewInfo>?
-    private(set) var adapterCommandType:AdapterCommandType
+    private(set) var firstTimeLoad: Bool
+    private(set) var failureMsg: String?
+    private(set) var pageNumber: Int
+    private(set) var enableScrollListener: Bool
+    private var currentList: Array<MovieViewInfo>?
+    private(set) var resultList: Array<MovieViewInfo>?
+    private(set) var adapterCommandType: AdapterCommandType
 
     /**
      * Create init state.
@@ -58,7 +58,7 @@ class UiModel {
      * Parameters: valuesToAdd - values to add to adapter.
      * Returns: new UiModel
      */
-    static func successState(pageNumber:Int, fullList:Array<MovieViewInfo>, valuesToAdd:Array<MovieViewInfo>) -> UiModel {
+    static func successState(pageNumber: Int, fullList: Array<MovieViewInfo>, valuesToAdd: Array<MovieViewInfo>) -> UiModel {
         return UiModel.init(firstTimeLoad: false,
                             failureMsg: nil,
                             pageNumber: pageNumber,
@@ -75,7 +75,7 @@ class UiModel {
      * Parameters: failureMsg - failure message to show
      * Returns: new UiModel
      */
-    static func failureState(pageNumber:Int, fullList:Array<MovieViewInfo>, failureMsg:String) -> UiModel {
+    static func failureState(pageNumber: Int, fullList: Array<MovieViewInfo>, failureMsg: String) -> UiModel {
         return UiModel.init(firstTimeLoad: false,
                             failureMsg: failureMsg,
                             pageNumber: pageNumber,
@@ -92,7 +92,7 @@ class UiModel {
      * @param fullList - latest full list that backs the adapter.
      * @return new UiModel
      */
-    static func inProgressState(firstTimeLoad:Bool, pageNumber:Int, fullList:Array<MovieViewInfo>?) -> UiModel {
+    static func inProgressState(firstTimeLoad: Bool, pageNumber: Int, fullList: Array<MovieViewInfo>?) -> UiModel {
         return UiModel.init(firstTimeLoad: firstTimeLoad,
                             failureMsg: nil,
                             pageNumber: pageNumber,
@@ -112,7 +112,7 @@ class UiModel {
         return arrayCopy
     }
 
-    fileprivate init(firstTimeLoad:Bool, failureMsg:String?, pageNumber:Int, enableScrollListener:Bool, currentList:Array<MovieViewInfo>?, resultList:Array<MovieViewInfo>?, adapterCommandType:AdapterCommandType) {
+    fileprivate init(firstTimeLoad: Bool, failureMsg: String?, pageNumber: Int, enableScrollListener: Bool, currentList: Array<MovieViewInfo>?, resultList: Array<MovieViewInfo>?, adapterCommandType: AdapterCommandType) {
         self.firstTimeLoad = firstTimeLoad
         self.failureMsg = failureMsg
         self.pageNumber = pageNumber
@@ -144,12 +144,12 @@ class UiModel {
             self.uiModel = uiModel
             
             self.firstTimeLoad = uiModel.firstTimeLoad
-            self.failureMsg = uiModel.failureMsg;
-            self.pageNumber = uiModel.pageNumber;
-            self.enableScrollListener = uiModel.enableScrollListener;
-            self.currentList = uiModel.getCurrentList();
-            self.resultList = uiModel.resultList;
-            self.adapterCommandType = uiModel.adapterCommandType;
+            self.failureMsg = uiModel.failureMsg
+            self.pageNumber = uiModel.pageNumber
+            self.enableScrollListener = uiModel.enableScrollListener
+            self.currentList = uiModel.getCurrentList()
+            self.resultList = uiModel.resultList
+            self.adapterCommandType = uiModel.adapterCommandType
         }
         
         init() {
@@ -172,7 +172,7 @@ class UiModel {
                     currentList = Array<MovieViewInfo>()
                 } else {
                     //shallow copy
-                    currentList = uiModel?.getCurrentList();
+                    currentList = uiModel?.getCurrentList()
                 }
             }
             
@@ -222,4 +222,3 @@ class UiModel {
         }
     }
 }
-

--- a/ReactiveArchitecture/Classes/nowplaying/service/Dates.swift
+++ b/ReactiveArchitecture/Classes/nowplaying/service/Dates.swift
@@ -29,8 +29,8 @@ import ObjectMapper
  * https://developers.themoviedb.org/3/movies/get-now-playing
  */
 class Dates: Mappable {
-    var maximum: String?
-    var minimum: String?
+    var maximum: String!
+    var minimum: String!
     
     required init?(map: Map) {
         

--- a/ReactiveArchitecture/Classes/nowplaying/service/Dates.swift
+++ b/ReactiveArchitecture/Classes/nowplaying/service/Dates.swift
@@ -29,10 +29,10 @@ import ObjectMapper
  * https://developers.themoviedb.org/3/movies/get-now-playing
  */
 class Dates: Mappable {
-    var maximum:String?
-    var minimum:String?
+    var maximum: String?
+    var minimum: String?
     
-    required init?(map: Map){
+    required init?(map: Map) {
         
     }
     

--- a/ReactiveArchitecture/Classes/nowplaying/service/Results.swift
+++ b/ReactiveArchitecture/Classes/nowplaying/service/Results.swift
@@ -25,37 +25,37 @@ import UIKit
 import ObjectMapper
 
 class Results: Mappable {
-    var poster_path: String?
+    var posterPath: String?
     var adult: Bool?
     var overview: String?
-    var release_date: String?
-    var genre_ids: [Int]?
+    var releaseDate: String?
+    var genreIds: [Int]?
     var id: Int?
-    var original_title: String?
-    var original_language: String?
+    var originalTitle: String?
+    var originalLanguage: String?
     var title: String?
     var popularity: Double?
-    var vote_count: Int?
+    var voteCount: Int?
     var video: Bool?
-    var vote_average: Double?
+    var voteAverage: Double?
     
     required init?(map: Map) {
         
     }
     
     func mapping(map: Map) {
-        poster_path <- map["poster_path"]
+        posterPath <- map["poster_path"]
         adult <- map["adult"]
         overview <- map["overview"]
-        release_date <- map["release_date"]
-        genre_ids <- map["genre_ids"]
+        releaseDate <- map["release_date"]
+        genreIds <- map["genre_ids"]
         id <- map["id"]
-        original_title <- map["original_title"]
-        original_language <- map["original_language"]
+        originalTitle <- map["original_title"]
+        originalLanguage <- map["original_language"]
         title <- map["title"]
         popularity <- map["popularity"]
-        vote_count <- map["vote_count"]
+        voteCount <- map["vote_count"]
         video <- map["video"]
-        vote_average <- map["vote_average"]
+        voteAverage <- map["vote_average"]
     }
 }

--- a/ReactiveArchitecture/Classes/nowplaying/service/Results.swift
+++ b/ReactiveArchitecture/Classes/nowplaying/service/Results.swift
@@ -25,19 +25,19 @@ import UIKit
 import ObjectMapper
 
 class Results: Mappable {
-    var posterPath: String?
-    var adult: Bool?
-    var overview: String?
-    var releaseDate: String?
-    var genreIds: [Int]?
-    var id: Int?
-    var originalTitle: String?
-    var originalLanguage: String?
-    var title: String?
-    var popularity: Double?
-    var voteCount: Int?
-    var video: Bool?
-    var voteAverage: Double?
+    var posterPath: String!
+    var adult: Bool!
+    var overview: String!
+    var releaseDate: String!
+    var genreIds: [Int]!
+    var id: Int!
+    var originalTitle: String!
+    var originalLanguage: String!
+    var title: String!
+    var popularity: Double!
+    var voteCount: Int!
+    var video: Bool!
+    var voteAverage: Double!
     
     required init?(map: Map) {
         

--- a/ReactiveArchitecture/Classes/nowplaying/service/Results.swift
+++ b/ReactiveArchitecture/Classes/nowplaying/service/Results.swift
@@ -39,7 +39,7 @@ class Results: Mappable {
     var video: Bool?
     var vote_average: Double?
     
-    required init?(map: Map){
+    required init?(map: Map) {
         
     }
     

--- a/ReactiveArchitecture/Classes/nowplaying/service/ServiceApi.swift
+++ b/ReactiveArchitecture/Classes/nowplaying/service/ServiceApi.swift
@@ -37,7 +37,5 @@ protocol ServiceApi {
      
      -Returns: Observble<ServiceResponse>
      */
-    func nowPlaying(apiKey: String, query:Dictionary<String, Int>) -> Observable<ServiceResponse>    
+    func nowPlaying(apiKey: String, query: Dictionary<String, Int>) -> Observable<ServiceResponse>    
 }
-
-

--- a/ReactiveArchitecture/Classes/nowplaying/service/ServiceApiImpl.swift
+++ b/ReactiveArchitecture/Classes/nowplaying/service/ServiceApiImpl.swift
@@ -40,7 +40,7 @@ class ServiceApiImpl: ServiceApi {
      -Parameter baseUrl: Base url for requests from service.
      */
     init(baseUrl: String) {
-        self.baseUrl = baseUrl;
+        self.baseUrl = baseUrl
         self.fullUrl = baseUrl + nowPlayingUrl
     }
     
@@ -71,7 +71,7 @@ class ServiceApiImpl: ServiceApi {
         let url = urlComps.url!
         
         return RxAlamofire.json(.get, url)
-            .map{json -> ServiceResponse in
+            .map {json -> ServiceResponse in
                 guard let serviceResponse = Mapper<ServiceResponse>().map(JSONObject: json) else {
                     throw APIError(code: "422", message: "ObjectMapper can't mapping")
                 }

--- a/ReactiveArchitecture/Classes/nowplaying/service/ServiceResponse.swift
+++ b/ReactiveArchitecture/Classes/nowplaying/service/ServiceResponse.swift
@@ -31,7 +31,7 @@ class ServiceResponse: Mappable {
     var total_pages: Int?
     var total_results: Int?
     
-    required init?(map: Map){
+    required init?(map: Map) {
         
     }
     

--- a/ReactiveArchitecture/Classes/nowplaying/service/ServiceResponse.swift
+++ b/ReactiveArchitecture/Classes/nowplaying/service/ServiceResponse.swift
@@ -28,8 +28,8 @@ class ServiceResponse: Mappable {
     var page: Int?
     var results: [Results]?
     var dates: Dates?
-    var total_pages: Int?
-    var total_results: Int?
+    var totalPages: Int?
+    var totalResults: Int?
     
     required init?(map: Map) {
         
@@ -39,8 +39,8 @@ class ServiceResponse: Mappable {
         page <- map["page"]
         results <- map["results"]
         dates <- map["dates"]
-        total_pages <- map["total_pages"]
-        total_results <- map["total_results"]
+        totalPages <- map["total_pages"]
+        totalResults <- map["total_results"]
     }
     
 }

--- a/ReactiveArchitecture/Classes/nowplaying/service/ServiceResponse.swift
+++ b/ReactiveArchitecture/Classes/nowplaying/service/ServiceResponse.swift
@@ -25,11 +25,11 @@ import UIKit
 import ObjectMapper
 
 class ServiceResponse: Mappable {
-    var page: Int?
-    var results: [Results]?
-    var dates: Dates?
-    var totalPages: Int?
-    var totalResults: Int?
+    var page: Int!
+    var results: [Results]!
+    var dates: Dates!
+    var totalPages: Int!
+    var totalResults: Int!
     
     required init?(map: Map) {
         

--- a/ReactiveArchitecture/Classes/nowplaying/view/MovieViewInfoImpl.swift
+++ b/ReactiveArchitecture/Classes/nowplaying/view/MovieViewInfoImpl.swift
@@ -24,7 +24,7 @@
 import UIKit
 
 class MovieViewInfoImpl: MovieViewInfo {
-    private static let RATE_NUMBER_TO_STAR = 8
+    private static let rateNumberToStar = 8
     private let dateFormatter = DateFormatter()
     private let movieInfo: MovieInfo
     
@@ -50,7 +50,7 @@ class MovieViewInfoImpl: MovieViewInfo {
     }
     
     func isHighRating() -> Bool {
-        return lround(movieInfo.getRating()) >= MovieViewInfoImpl.RATE_NUMBER_TO_STAR
+        return lround(movieInfo.getRating()) >= MovieViewInfoImpl.rateNumberToStar
     }
     
 

--- a/ReactiveArchitecture/Classes/nowplaying/view/MovieViewInfoImpl.swift
+++ b/ReactiveArchitecture/Classes/nowplaying/view/MovieViewInfoImpl.swift
@@ -24,9 +24,9 @@
 import UIKit
 
 class MovieViewInfoImpl: MovieViewInfo {
-    private static let RATE_NUMBER_TO_STAR = 8;
+    private static let RATE_NUMBER_TO_STAR = 8
     private let dateFormatter = DateFormatter()
-    private let movieInfo:MovieInfo
+    private let movieInfo: MovieInfo
     
     init(movieInfo: MovieInfo) {
         self.movieInfo = movieInfo

--- a/ReactiveArchitecture/Classes/nowplaying/viewcontroller/NowPlayingTableViewController.swift
+++ b/ReactiveArchitecture/Classes/nowplaying/viewcontroller/NowPlayingTableViewController.swift
@@ -44,12 +44,12 @@ class NowPlayingTableViewController: UITableViewController {
      Add passed in list to table view with animation for each entry to add
      Parameters: listToAdd - list to add
     */
-    func addAll(listToAdd: Array<MovieViewInfo>!) -> Void {
+    func addAll(listToAdd: Array<MovieViewInfo>!) {
         for movieViewInfo: MovieViewInfo in listToAdd {
             objectList.append(movieViewInfo)
             
             let indexPath = IndexPath.init(row: self.objectList.count - 1, section: 0)
-            let indexPathArray : [IndexPath] = [indexPath]
+            let indexPathArray: [IndexPath] = [indexPath]
             
             tableView.insertRows(at: indexPathArray, with: UITableViewRowAnimation.left)
         }
@@ -59,11 +59,11 @@ class NowPlayingTableViewController: UITableViewController {
      Add passed in value to table view
      Parameters: listToAdd - list to add
      */
-    func add(itemToAdd: MovieViewInfo!) -> Void {
+    func add(itemToAdd: MovieViewInfo!) {
         objectList.append(itemToAdd!)
         
         let indexPath = IndexPath.init(row: self.objectList.count - 1, section: 0)
-        let indexPathArray : [IndexPath] = [indexPath]
+        let indexPathArray: [IndexPath] = [indexPath]
         tableView.insertRows(at: indexPathArray, with: UITableViewRowAnimation.left)
     }
     
@@ -91,12 +91,12 @@ class NowPlayingTableViewController: UITableViewController {
     /**
     Remove an item at a specific position.
     */
-    func remove(objectToRemove: MovieViewInfo) -> Void {
+    func remove(objectToRemove: MovieViewInfo) {
         let index = objectList.indexOf(element: objectToRemove)
         objectList.removeObject(element: objectToRemove)
         
         let indexPath = IndexPath.init(row: index, section: 0)
-        let indexPathArray : [IndexPath] = [indexPath]
+        let indexPathArray: [IndexPath] = [indexPath]
         tableView.deleteRows(at: indexPathArray, with: UITableViewRowAnimation.left)
     }
     
@@ -143,7 +143,5 @@ class NowPlayingTableViewController: UITableViewController {
 }
 
 protocol LoadMoreListener {
-    func loadMore() -> Void
+    func loadMore()
 }
-
-

--- a/ReactiveArchitecture/Classes/nowplaying/viewcontroller/NowPlayingTableViewController.swift
+++ b/ReactiveArchitecture/Classes/nowplaying/viewcontroller/NowPlayingTableViewController.swift
@@ -59,8 +59,8 @@ class NowPlayingTableViewController: UITableViewController {
      Add passed in value to table view
      Parameters: listToAdd - list to add
      */
-    func add(itemToAdd: MovieViewInfo!) {
-        objectList.append(itemToAdd!)
+    func add(itemToAdd: MovieViewInfo) {
+        objectList.append(itemToAdd)
         
         let indexPath = IndexPath.init(row: self.objectList.count - 1, section: 0)
         let indexPathArray: [IndexPath] = [indexPath]

--- a/ReactiveArchitecture/Classes/nowplaying/viewcontroller/NowPlayingTableViewController.swift
+++ b/ReactiveArchitecture/Classes/nowplaying/viewcontroller/NowPlayingTableViewController.swift
@@ -81,7 +81,7 @@ class NowPlayingTableViewController: UITableViewController {
     Returns: MovieViewInfo at given position or nil
     */
     func getItem(position: Int) -> MovieViewInfo? {
-        if (objectList.count > position) {
+        if objectList.count > position {
             return objectList[position]
         } else {
             return nil
@@ -116,7 +116,8 @@ class NowPlayingTableViewController: UITableViewController {
         let movieViewInfo: MovieViewInfo = objectList[indexPath.row]
         
         //Load & Address Cell (no longer returns nil when using storyboard)
-        if (movieViewInfo is MovieViewInfoImpl) {
+        if movieViewInfo is MovieViewInfoImpl {
+            // swiftlint:disable:next force_cast
             let movieCell: MovieCell = tableView.dequeueReusableCell(withIdentifier: "MovieCellIdentifier", for: indexPath) as! MovieCell
             
             //Address Cell
@@ -124,17 +125,19 @@ class NowPlayingTableViewController: UITableViewController {
             movieCell.releaseDateLabel.text = movieViewInfo.getReleaseDate()
             movieCell.ratingLabel.text = movieViewInfo.getRating()
             
-            if (movieViewInfo.isHighRating()) {
+            if movieViewInfo.isHighRating() {
                 movieCell.highRatingImageView.isHidden = false
             } else {
                 movieCell.highRatingImageView.isHidden = true
             }
             
-            let url = URL(string: movieViewInfo.getPictureUrl())!
-            movieCell.moviePosterImageView.af_setImage(withURL: url)
+            if let url = URL(string: movieViewInfo.getPictureUrl()) {
+                movieCell.moviePosterImageView.af_setImage(withURL: url)
+            }
             
             return movieCell
         } else {
+            // swiftlint:disable:next force_cast
             let progressCell: ProgressCell = tableView.dequeueReusableCell(withIdentifier: "ProgressCellIdentifier", for: indexPath) as! ProgressCell
             progressCell.progressActivityIndicatorView.startAnimating()
             return progressCell

--- a/ReactiveArchitecture/Classes/nowplaying/viewcontroller/NowPlayingViewController.swift
+++ b/ReactiveArchitecture/Classes/nowplaying/viewcontroller/NowPlayingViewController.swift
@@ -86,10 +86,12 @@ class NowPlayingViewController: UIViewController {
      * Bind to all data in {@link NowPlayingViewModel}.
      */
     private func bind() {
+        guard let uiModels = nowPlayingViewModel?.getUiModels() else { return }
+        
         //
         //Bind to UiModel
         //
-       _ = compositeDisposable.insert(nowPlayingViewModel!.getUiModels()
+        _ = compositeDisposable.insert(uiModels
             .subscribe(onNext: { uiModel in
                 self.processUiModel(uiModel: uiModel)
             }, onError: {(error) in
@@ -185,8 +187,6 @@ class NowPlayingViewController: UIViewController {
             //Process last adapter command
             if uiModel.adapterCommandType == .addData {
                 nowPlayingTableViewController!.addAll(listToAdd: uiModel.resultList!)
-            } else if uiModel.adapterCommandType == .showInProgress {
-                nowPlayingTableViewController?.add(itemToAdd: nil)
             }
             
             //make table visible

--- a/ReactiveArchitecture/Classes/nowplaying/viewcontroller/NowPlayingViewController.swift
+++ b/ReactiveArchitecture/Classes/nowplaying/viewcontroller/NowPlayingViewController.swift
@@ -72,8 +72,9 @@ class NowPlayingViewController: UIViewController {
     
      override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
         let segueName = segue.identifier
-        if (segueName?.caseInsensitiveCompare("EmbedSegueContainer") == ComparisonResult.orderedSame) {
-            nowPlayingTableViewController = (segue.destination as! NowPlayingTableViewController)
+        if segueName?.caseInsensitiveCompare("EmbedSegueContainer") == .orderedSame,
+            let nowPlayingViewController = segue.destination as? NowPlayingTableViewController {
+            nowPlayingTableViewController = nowPlayingViewController
             tableView = nowPlayingTableViewController!.tableView
             nowPlayingTableViewController!.tableView.isHidden = true
         }
@@ -108,7 +109,7 @@ class NowPlayingViewController: UIViewController {
         //
         //Guard
         //
-        if (scrollDisposable != nil) {
+        guard scrollDisposable == nil else {
             return
         }
         
@@ -120,7 +121,7 @@ class NowPlayingViewController: UIViewController {
                 let scrollEventCalculator: ScrollEventCalculator = ScrollEventCalculator.init(scrollView: self.tableView!)
 
                 //Only handle 'is at end' of list scroll events
-                if (scrollEventCalculator.isAtScrollEnd()) {
+                if scrollEventCalculator.isAtScrollEnd() {
                     let scrollEvent: ScrollEvent = ScrollEvent.init(pageNumber: self.pageNumber! + 1)
 
                     return Observable.just(scrollEvent)
@@ -148,7 +149,7 @@ class NowPlayingViewController: UIViewController {
      * Unbind from scroll events.
      */
     private func unbindFromScrollEvent() {
-        if (scrollDisposable != nil) {
+        if scrollDisposable != nil {
             scrollDisposable?.dispose()
         }
         scrollDisposable = nil
@@ -167,7 +168,7 @@ class NowPlayingViewController: UIViewController {
         //
         //Update progressBar
         //
-        if (!uiModel.firstTimeLoad) {
+        if !uiModel.firstTimeLoad {
             activityIndicator.stopAnimating()
         }
         
@@ -179,12 +180,12 @@ class NowPlayingViewController: UIViewController {
         //
         //Update adapter
         //
-        if (self.nowPlayingTableViewController!.tableView.isHidden) {
+        if self.nowPlayingTableViewController!.tableView.isHidden {
             
             //Process last adapter command
-            if (uiModel.adapterCommandType == AdapterCommandType.ADD_DATA) {
+            if uiModel.adapterCommandType == .addData {
                 nowPlayingTableViewController!.addAll(listToAdd: uiModel.resultList!)
-            } else if (uiModel.adapterCommandType == AdapterCommandType.SHOW_IN_PROGRESS) {
+            } else if uiModel.adapterCommandType == .showInProgress {
                 nowPlayingTableViewController?.add(itemToAdd: nil)
             }
             
@@ -195,18 +196,18 @@ class NowPlayingViewController: UIViewController {
             let scrollEvent: ScrollEvent = ScrollEvent.init(pageNumber: self.pageNumber! + 1)
             nowPlayingViewModel?.processUiEvent(uiEvent: scrollEvent)
         } else {
-            if (uiModel.adapterCommandType == AdapterCommandType.ADD_DATA) {
+            if uiModel.adapterCommandType == .addData {
                 DDLogInfo("Thread name: " + Thread.current.debugDescription + "  Add adapter data on UiModel")
                 //Remove Spinner
-                if (nowPlayingTableViewController!.getItemCount() > 0) {
+                if nowPlayingTableViewController!.getItemCount() > 0 {
                     let positionToRemove: Int = nowPlayingTableViewController!.getItemCount() - 1
                     let objectToRemove: MovieViewInfo = nowPlayingTableViewController!.getItem(position: positionToRemove)!
-                    nowPlayingTableViewController?.remove(objectToRemove:objectToRemove)
+                    nowPlayingTableViewController?.remove(objectToRemove: objectToRemove)
                 }
                 
                 //Add Data
                 nowPlayingTableViewController?.addAll(listToAdd: uiModel.resultList!)
-            } else if (uiModel.adapterCommandType == AdapterCommandType.SHOW_IN_PROGRESS) {
+            } else if uiModel.adapterCommandType == .showInProgress {
                 //Add ProgressViewInfoImpl to table. ProgressViewInfoImpl shows spinner in table logic.
                 nowPlayingTableViewController?.add(itemToAdd: ProgressViewInfoImpl())
                 
@@ -218,14 +219,14 @@ class NowPlayingViewController: UIViewController {
         //
         //Error Messages
         //
-        if (uiModel.failureMsg != nil && !uiModel.failureMsg!.isEmpty) {
+        if uiModel.failureMsg != nil && !uiModel.failureMsg!.isEmpty {
             self.view.makeToast(NSLocalizedString("error_msg", comment: ""))
         }
         
         //
         //Scroll Listener (iOS has to be done last so we don't trigger continuous loads)
         //
-        if (uiModel.enableScrollListener) {
+        if uiModel.enableScrollListener {
             bindToScrollEvent()
         } else {
             unbindFromScrollEvent()

--- a/ReactiveArchitecture/Classes/nowplaying/viewcontroller/NowPlayingViewController.swift
+++ b/ReactiveArchitecture/Classes/nowplaying/viewcontroller/NowPlayingViewController.swift
@@ -28,11 +28,11 @@ import CocoaLumberjack
 import Toast_Swift
 
 class NowPlayingViewController: UIViewController {
-    private var nowPlayingTableViewController: NowPlayingTableViewController?
-    private var tableView: UITableView?
+    private var nowPlayingTableViewController: NowPlayingTableViewController!
+    private var tableView: UITableView!
     private let compositeDisposable = CompositeDisposable()
     private var scrollDisposable: Disposable?
-    private var pageNumber: Int?
+    private var pageNumber: Int = 0
     
     //
     //UI Variables
@@ -75,8 +75,8 @@ class NowPlayingViewController: UIViewController {
         if segueName?.caseInsensitiveCompare("EmbedSegueContainer") == .orderedSame,
             let nowPlayingViewController = segue.destination as? NowPlayingTableViewController {
             nowPlayingTableViewController = nowPlayingViewController
-            tableView = nowPlayingTableViewController!.tableView
-            nowPlayingTableViewController!.tableView.isHidden = true
+            tableView = nowPlayingTableViewController.tableView
+            nowPlayingTableViewController.tableView.isHidden = true
         }
      }
     
@@ -111,20 +111,20 @@ class NowPlayingViewController: UIViewController {
         //
         //Guard
         //
-        guard scrollDisposable == nil else {
+        guard self.scrollDisposable == nil else {
             return
         }
         
         //
         //Bind
         //
-        scrollDisposable = self.tableView!.rx.didScroll
+        let scrollDisposable = self.tableView.rx.didScroll
             .flatMap { scrollView -> Observable<ScrollEvent> in
-                let scrollEventCalculator: ScrollEventCalculator = ScrollEventCalculator.init(scrollView: self.tableView!)
+                let scrollEventCalculator: ScrollEventCalculator = ScrollEventCalculator.init(scrollView: self.tableView)
 
                 //Only handle 'is at end' of list scroll events
                 if scrollEventCalculator.isAtScrollEnd() {
-                    let scrollEvent: ScrollEvent = ScrollEvent.init(pageNumber: self.pageNumber! + 1)
+                    let scrollEvent: ScrollEvent = ScrollEvent.init(pageNumber: self.pageNumber + 1)
 
                     return Observable.just(scrollEvent)
                 } else {
@@ -142,9 +142,10 @@ class NowPlayingViewController: UIViewController {
                 DDLogError(errorMsg)
                 fatalError(errorMsg)
             })
+        self.scrollDisposable = scrollDisposable
         
         //Note - ignore the returned result. I don't need to keep track of keys
-        _ = compositeDisposable.insert(scrollDisposable!)
+        _ = compositeDisposable.insert(scrollDisposable)
     }
     
     /**
@@ -179,47 +180,51 @@ class NowPlayingViewController: UIViewController {
         //
         pageNumber = uiModel.pageNumber
         
+        
         //
         //Update adapter
         //
-        if self.nowPlayingTableViewController!.tableView.isHidden {
+        if self.nowPlayingTableViewController.tableView.isHidden {
             
             //Process last adapter command
-            if uiModel.adapterCommandType == .addData {
-                nowPlayingTableViewController!.addAll(listToAdd: uiModel.resultList!)
+            if uiModel.adapterCommandType == .addData, let list = uiModel.resultList {
+                nowPlayingTableViewController.addAll(listToAdd: list)
             }
             
             //make table visible
-            self.nowPlayingTableViewController!.tableView.isHidden = false
+            self.nowPlayingTableViewController.tableView.isHidden = false
             
             //Trigger first load
-            let scrollEvent: ScrollEvent = ScrollEvent.init(pageNumber: self.pageNumber! + 1)
+            let scrollEvent: ScrollEvent = ScrollEvent.init(pageNumber: self.pageNumber + 1)
             nowPlayingViewModel?.processUiEvent(uiEvent: scrollEvent)
         } else {
             if uiModel.adapterCommandType == .addData {
                 DDLogInfo("Thread name: " + Thread.current.debugDescription + "  Add adapter data on UiModel")
                 //Remove Spinner
-                if nowPlayingTableViewController!.getItemCount() > 0 {
-                    let positionToRemove: Int = nowPlayingTableViewController!.getItemCount() - 1
-                    let objectToRemove: MovieViewInfo = nowPlayingTableViewController!.getItem(position: positionToRemove)!
-                    nowPlayingTableViewController?.remove(objectToRemove: objectToRemove)
+                if nowPlayingTableViewController.getItemCount() > 0 {
+                    let positionToRemove: Int = nowPlayingTableViewController.getItemCount() - 1
+                    if let objectToRemove = nowPlayingTableViewController.getItem(position: positionToRemove) {
+                        nowPlayingTableViewController?.remove(objectToRemove: objectToRemove)
+                    }
                 }
                 
                 //Add Data
-                nowPlayingTableViewController?.addAll(listToAdd: uiModel.resultList!)
+                if let list = uiModel.resultList {
+                    nowPlayingTableViewController?.addAll(listToAdd: list)
+                }
             } else if uiModel.adapterCommandType == .showInProgress {
                 //Add ProgressViewInfoImpl to table. ProgressViewInfoImpl shows spinner in table logic.
                 nowPlayingTableViewController?.add(itemToAdd: ProgressViewInfoImpl())
                 
-                let indexPath = IndexPath.init(row: nowPlayingTableViewController!.getItemCount() - 1, section: 0)
-                self.tableView!.scrollToRow(at: indexPath, at: .top, animated: true)
+                let indexPath = IndexPath.init(row: nowPlayingTableViewController.getItemCount() - 1, section: 0)
+                self.tableView.scrollToRow(at: indexPath, at: .top, animated: true)
             }
         }
         
         //
         //Error Messages
         //
-        if uiModel.failureMsg != nil && !uiModel.failureMsg!.isEmpty {
+        if uiModel.failureMsg != nil && uiModel.failureMsg?.isEmpty == false {
             self.view.makeToast(NSLocalizedString("error_msg", comment: ""))
         }
         

--- a/ReactiveArchitecture/Classes/nowplaying/viewcontroller/NowPlayingViewController.swift
+++ b/ReactiveArchitecture/Classes/nowplaying/viewcontroller/NowPlayingViewController.swift
@@ -104,20 +104,20 @@ class NowPlayingViewController: UIViewController {
     /**
      * Bind to scroll events.
      */
-    private func bindToScrollEvent() -> Void {
+    private func bindToScrollEvent() {
         //
         //Guard
         //
         if (scrollDisposable != nil) {
-            return;
+            return
         }
         
         //
         //Bind
         //
         scrollDisposable = self.tableView!.rx.didScroll
-            .flatMap{ scrollView -> Observable<ScrollEvent> in
-                let scrollEventCalculator:ScrollEventCalculator = ScrollEventCalculator.init(scrollView: self.tableView!)
+            .flatMap { scrollView -> Observable<ScrollEvent> in
+                let scrollEventCalculator: ScrollEventCalculator = ScrollEventCalculator.init(scrollView: self.tableView!)
 
                 //Only handle 'is at end' of list scroll events
                 if (scrollEventCalculator.isAtScrollEnd()) {
@@ -147,7 +147,7 @@ class NowPlayingViewController: UIViewController {
     /**
      * Unbind from scroll events.
      */
-    private func unbindFromScrollEvent() -> Void {
+    private func unbindFromScrollEvent() {
         if (scrollDisposable != nil) {
             scrollDisposable?.dispose()
         }
@@ -158,7 +158,7 @@ class NowPlayingViewController: UIViewController {
      * Bind to {@link UiModel}.
      * Parameter: uiModel - the {@link UiModel} from {@link NowPlayingViewModel} that backs the UI.
      */
-    private func processUiModel(uiModel: UiModel) -> Void {
+    private func processUiModel(uiModel: UiModel) {
         /*
          Note - Keep the logic here as SIMPLE as possible.
          */
@@ -232,5 +232,3 @@ class NowPlayingViewController: UIViewController {
         }
     }
 }
-
-

--- a/ReactiveArchitecture/Classes/nowplaying/viewmodel/NowPlayingViewModel.swift
+++ b/ReactiveArchitecture/Classes/nowplaying/viewmodel/NowPlayingViewModel.swift
@@ -30,10 +30,10 @@ import RxSwift
  */
 class NowPlayingViewModel {
     private let initialUiModel: UiModel = UiModel.initState()
-    private var uiModelObservable:Observable<UiModel>?
-    private let serviceController:ServiceController
-    private let publishSubject:PublishSubject<UiEvent> = PublishSubject.init()
-    private var nowPlayingInteractor:NowPlayingInteractor?
+    private var uiModelObservable: Observable<UiModel>?
+    private let serviceController: ServiceController
+    private let publishSubject: PublishSubject<UiEvent> = PublishSubject.init()
+    private var nowPlayingInteractor: NowPlayingInteractor?
     private var backgroundScheduler: SchedulerType?
     private var mainScheduler: SchedulerType?
     
@@ -52,8 +52,8 @@ class NowPlayingViewModel {
      Process events from the UI.
      parameter uiEvent - 
      */
-    func processUiEvent(uiEvent:UiEvent) -> Void {
-        DDLogInfo("Thread name: " + Thread.current.debugDescription + " Process UiEvent");
+    func processUiEvent(uiEvent: UiEvent) {
+        DDLogInfo("Thread name: " + Thread.current.debugDescription + " Process UiEvent")
         publishSubject.onNext(uiEvent)
     }
     
@@ -98,9 +98,9 @@ class NowPlayingViewModel {
             //Note - unlike android, there is no io or computation scheduler. Each must be redefined with a specific queue as per GCD.
             .observeOn(backgroundScheduler!)
             //Translate UiEvents into Actions
-            .flatMap{uiEvent -> Observable<Action> in
-                DDLogInfo("Thread name: " + Thread.current.debugDescription + " Translate UiEvents into Actions");
-                let scrollAction:ScrollAction = ScrollAction.init(pageNumber: (uiEvent as! ScrollEvent).pageNumber)
+            .flatMap {uiEvent -> Observable<Action> in
+                DDLogInfo("Thread name: " + Thread.current.debugDescription + " Translate UiEvents into Actions")
+                let scrollAction: ScrollAction = ScrollAction.init(pageNumber: (uiEvent as! ScrollEvent).pageNumber)
                 return Observable.just(scrollAction)
             }
             //Asynchronous Actions To Interactor (Syntax: https://github.com/ReactiveX/RxSwift/issues/876)
@@ -170,5 +170,3 @@ class NowPlayingViewModel {
         return movieViewInfoList
     }
 }
-
-

--- a/ReactiveArchitecture/Classes/nowplaying/viewmodel/NowPlayingViewModel.swift
+++ b/ReactiveArchitecture/Classes/nowplaying/viewmodel/NowPlayingViewModel.swift
@@ -34,8 +34,8 @@ class NowPlayingViewModel {
     private let serviceController: ServiceController
     private let publishSubject: PublishSubject<UiEvent> = PublishSubject.init()
     private var nowPlayingInteractor: NowPlayingInteractor?
-    private var backgroundScheduler: SchedulerType?
-    private var mainScheduler: SchedulerType?
+    private var backgroundScheduler: SchedulerType!
+    private var mainScheduler: SchedulerType!
     
     /**
      Constructor.
@@ -96,7 +96,7 @@ class NowPlayingViewModel {
     func bind() {
         uiModelObservable = publishSubject
             //Note - unlike android, there is no io or computation scheduler. Each must be redefined with a specific queue as per GCD.
-            .observeOn(backgroundScheduler!)
+            .observeOn(backgroundScheduler)
             .map { $0 as? ScrollEvent }
             .ignoreNil()
             //Translate UiEvents into Actions
@@ -142,7 +142,7 @@ class NowPlayingViewModel {
             //start with the initial value. 
             .startWith(initialUiModel)
             //Publish results to main thread.
-            .observeOn(mainScheduler!)
+            .observeOn(mainScheduler)
             //Save history for late subscribers.
             .replay(1)
             /*

--- a/ReactiveArchitecture/Classes/nowplaying/viewmodel/NowPlayingViewModel.swift
+++ b/ReactiveArchitecture/Classes/nowplaying/viewmodel/NowPlayingViewModel.swift
@@ -61,8 +61,8 @@ class NowPlayingViewModel {
      Get the observable holding the {@link UiModel}
      returns: Observable<UiModel>
     */
-    func getUiModels() -> Observable<UiModel> {
-        return uiModelObservable!
+    func getUiModels() -> Observable<UiModel>? {
+        return uiModelObservable
     }
     
     /**
@@ -117,11 +117,11 @@ class NowPlayingViewModel {
                 DDLogInfo("Thread name: " + Thread.current.debugDescription + ". Scan Results to UiModel")
 
                 switch result.getType() {
-                case ResultType.inFlight:
+                case .inFlight:
                     return UiModel.inProgressState(firstTimeLoad: result.pageNumber == 1,
                                                    pageNumber: result.pageNumber,
                                                    fullList: uiModel.getCurrentList())
-                case ResultType.success:
+                case .success:
                     let listToAdd: Array<MovieViewInfo>  = self.translateResultsForUi(movieInfoList: result.result!)
                     var currentList: Array<MovieViewInfo> = uiModel.getCurrentList()!
                     currentList.append(contentsOf: listToAdd)
@@ -130,7 +130,7 @@ class NowPlayingViewModel {
                                                 fullList: currentList,
                                                 valuesToAdd: listToAdd)
                     
-                case ResultType.failure:
+                case .failure:
                     DDLogError(result.error!.localizedDescription)
                     return UiModel.failureState(
                         pageNumber: result.pageNumber - 1,

--- a/ReactiveArchitectureTests/nowplaying/controller/ServiceControllerImplTest.swift
+++ b/ReactiveArchitectureTests/nowplaying/controller/ServiceControllerImplTest.swift
@@ -89,6 +89,7 @@ class ServiceControllerImplTest: RxSwiftTest {
         let movieInfo: MovieInfo = nowPlayingInfo.getMovies()[0]
         assertThat(movieInfo.getPictureUrl(), matchesPattern(IMAGE_PATH + "/tnmL0g604PDRJwGJ5fsUSYKFo9.jpg", options: .caseInsensitive))
         assertThat(movieInfo.getRating(), equalTo(7.2))
+        // TODO: This fails outside of US timezones
         assertThat(movieInfo.getReleaseDate().description, equalTo("2017-03-15 04:00:00 +0000"))
         assertThat(movieInfo.getTitle(), equalTo("Beauty and the Beast"))
     }

--- a/ReactiveArchitectureTests/nowplaying/interactor/NowPlayingInteractorTest.swift
+++ b/ReactiveArchitectureTests/nowplaying/interactor/NowPlayingInteractorTest.swift
@@ -87,7 +87,7 @@ class NowPlayingInteractorTest: RxSwiftTest {
         TestableObserverUtil.assertNoErrors(testObserver: testableObserver)
         TestableObserverUtil.assertValueCount(testObserver: testableObserver, count: 2)
         
-        //IN_FLIGHT Test
+        //inFlight Test
         let result: Result = testableObserver.events[0].value.element!
         assertThat(result, not(nilValue()))
         assertThat(result, instanceOf(ScrollResult.self))
@@ -96,9 +96,9 @@ class NowPlayingInteractorTest: RxSwiftTest {
         assertThat(scrollResult.pageNumber, equalTo(pageNumber))
         assertThat(scrollResult.error, nilValue())
         assertThat(scrollResult.result, nilValue())
-        assertThat(scrollResult.getType(), equalTo(ResultType.IN_FLIGHT) )
+        assertThat(scrollResult.getType(), equalTo(ResultType.inFlight) )
         
-        //SUCCESS
+        //success
         let resultSuccess: Result = testableObserver.events[1].value.element!
         assertThat(resultSuccess, not(nilValue()))
         assertThat(resultSuccess, instanceOf(ScrollResult.self))
@@ -108,7 +108,7 @@ class NowPlayingInteractorTest: RxSwiftTest {
         assertThat(scrollResultSuccess.error, nilValue())
         assertThat(scrollResultSuccess.result!.count, greaterThan(0))
         assertThat(scrollResultSuccess.result!, hasCount(5))
-        assertThat(scrollResultSuccess.getType(), equalTo(ResultType.SUCCESS))
+        assertThat(scrollResultSuccess.getType(), equalTo(ResultType.success))
     
         //Note - sadly with generics you have problems doing tests without a concrete class to caast to.
         for i in 0...4 {
@@ -125,7 +125,7 @@ class NowPlayingInteractorTest: RxSwiftTest {
         let testableObserver = testScheduler!.createObserver(Result.self)
         
         let msg: String = "Error Message";
-        let testError: TestError = TestError.RuntimeError(message: msg)
+        let testError: TestError = TestError.runtimeError(message: msg)
         
         mockServiceController = MockServiceController.init(returnValue: Observable.error(testError))
         
@@ -148,7 +148,7 @@ class NowPlayingInteractorTest: RxSwiftTest {
         TestableObserverUtil.assertNoErrors(testObserver: testableObserver)
         TestableObserverUtil.assertValueCount(testObserver: testableObserver, count: 2)
         
-        //IN_FLIGHT Test
+        //inFlight Test
         let result: Result = testableObserver.events[0].value.element!
         assertThat(result, not(nilValue()))
         assertThat(result, instanceOf(ScrollResult.self))
@@ -157,9 +157,9 @@ class NowPlayingInteractorTest: RxSwiftTest {
         assertThat(scrollResult.pageNumber, equalTo(pageNumber))
         assertThat(scrollResult.error, nilValue())
         assertThat(scrollResult.result, nilValue())
-        assertThat(scrollResult.getType(), equalTo(ResultType.IN_FLIGHT) )
+        assertThat(scrollResult.getType(), equalTo(ResultType.inFlight) )
 
-        //FAILURE
+        //failure
         let failureResult: Result = testableObserver.events[1].value.element!
         assertThat(failureResult, not(nilValue()))
         assertThat(failureResult, instanceOf(ScrollResult.self))
@@ -171,7 +171,7 @@ class NowPlayingInteractorTest: RxSwiftTest {
         let testErrorUnderTest : TestError = scrollResultFailure.error! as! TestError
         assertThat(testErrorUnderTest.localizedDescription, equalTo(msg))
         assertThat(scrollResultFailure.result, nilValue())
-        assertThat(scrollResultFailure.getType(), equalTo(ResultType.FAILURE))
+        assertThat(scrollResultFailure.getType(), equalTo(ResultType.failure))
     }
     
     

--- a/ReactiveArchitectureTests/nowplaying/service/ServiceApiTest.swift
+++ b/ReactiveArchitectureTests/nowplaying/service/ServiceApiTest.swift
@@ -76,7 +76,7 @@ class ServiceApiTest: XCTestCase {
         assertThat((serviceResponse?.page)!, equalTo(1))
         assertThat((serviceResponse?.results)!, not(nilValue()))
         assertThat((serviceResponse?.dates)!, not(nilValue()))
-        assertThat((serviceResponse?.total_pages)!, greaterThan(0))
-        assertThat((serviceResponse?.total_results)!, greaterThan(0))
+        assertThat((serviceResponse?.totalPages)!, greaterThan(0))
+        assertThat((serviceResponse?.totalResults)!, greaterThan(0))
     }
 }

--- a/ReactiveArchitectureTests/nowplaying/util/TestError.swift
+++ b/ReactiveArchitectureTests/nowplaying/util/TestError.swift
@@ -26,13 +26,13 @@ import Foundation
  Custom Error
  */
 public enum TestError : Error {
-    case RuntimeError(message: String)
+    case runtimeError(message: String)
 }
 
 extension TestError: LocalizedError {
     var localizedDescription: String {
         switch self {
-        case .RuntimeError(message: let message):
+        case .runtimeError(message: let message):
             return "\(message)"
         }
     }

--- a/ReactiveArchitectureTests/nowplaying/viewmodel/NowPlayingViewModelTest.swift
+++ b/ReactiveArchitectureTests/nowplaying/viewmodel/NowPlayingViewModelTest.swift
@@ -30,6 +30,8 @@ import AlamofireObjectMapper
 import ObjectMapper
 import CocoaLumberjack
 
+@testable import ReactiveArchitecture
+
 class NowPlayingViewModelTest: RxSwiftTest {
     private var mockServiceController: MockServiceController!
     
@@ -65,7 +67,7 @@ class NowPlayingViewModelTest: RxSwiftTest {
         //
         //Act
         //
-        nowPlayingViewModel.getUiModels()
+        nowPlayingViewModel.getUiModels()!
             .subscribe(testableObserver)
             .disposed(by: self.disboseBag!)
         testScheduler!.start()
@@ -108,7 +110,7 @@ class NowPlayingViewModelTest: RxSwiftTest {
         //
         //Act
         //
-        nowPlayingViewModel.getUiModels()
+        nowPlayingViewModel.getUiModels()!
             .subscribe(testableObserver)
             .disposed(by: self.disboseBag!)
         nowPlayingViewModel.processUiEvent(uiEvent: scrollEvent)
@@ -168,7 +170,7 @@ class NowPlayingViewModelTest: RxSwiftTest {
         //
         //Act
         //
-        nowPlayingViewModel.getUiModels()
+        nowPlayingViewModel.getUiModels()!
             .subscribe(testableObserver)
             .disposed(by: self.disboseBag!)
         nowPlayingViewModel.processUiEvent(uiEvent: scrollEvent)

--- a/ReactiveArchitectureTests/nowplaying/viewmodel/NowPlayingViewModelTest.swift
+++ b/ReactiveArchitectureTests/nowplaying/viewmodel/NowPlayingViewModelTest.swift
@@ -79,7 +79,7 @@ class NowPlayingViewModelTest: RxSwiftTest {
         let uiModel: UiModel = testableObserver.events[0].value.element!
         assertThat(uiModel, not(nilValue()))
         assertThat(uiModel.firstTimeLoad == true)
-        assertThat(uiModel.adapterCommandType, equalTo(AdapterCommandType.DO_NOTHING))
+        assertThat(uiModel.adapterCommandType, equalTo(AdapterCommandType.doNothing))
         assertThat(uiModel.getCurrentList()!.count, equalTo(0))
         assertThat(uiModel.resultList, nilValue())
         assertThat(uiModel.failureMsg, nilValue())
@@ -124,7 +124,7 @@ class NowPlayingViewModelTest: RxSwiftTest {
         let uiModel: UiModel = testableObserver.events[1].value.element!
         assertThat(uiModel, not(nilValue()))
         assertThat(uiModel.firstTimeLoad == true)
-        assertThat(uiModel.adapterCommandType, equalTo(AdapterCommandType.DO_NOTHING))
+        assertThat(uiModel.adapterCommandType, equalTo(AdapterCommandType.doNothing))
         assertThat(uiModel.getCurrentList()!.count, equalTo(0))
         assertThat(uiModel.resultList, nilValue())
         assertThat(uiModel.failureMsg, nilValue())
@@ -184,7 +184,7 @@ class NowPlayingViewModelTest: RxSwiftTest {
         let uiModel: UiModel = testableObserver.events[2].value.element!
         assertThat(uiModel, not(nilValue()))
         assertThat(uiModel.firstTimeLoad == false)
-        assertThat(uiModel.adapterCommandType, equalTo(AdapterCommandType.ADD_DATA))
+        assertThat(uiModel.adapterCommandType, equalTo(AdapterCommandType.addData))
         assertThat(uiModel.getCurrentList()!.count, greaterThan(0))
         assertThat(uiModel.getCurrentList()!.count, equalTo(1))
         assertThat(uiModel.resultList!.count, greaterThan(0))


### PR DESCRIPTION
This PR adds swiftlint (install with brew) and fixes as much as I could without doing bigger refactoring.

Hopefully without being annoying, here's some issues I noticed along the way:
* If data comes back from the API in a format we don't expect, the app will likely crash. The code is force unwrapping deserialised API response model vars all over the place. This is a failure of AlamofireObjectMapper where you have to make all vars optional. We moved away from this on PlayPlex to the built in swift 4 `Codable` protocol. This is much nicer, you can use immutable non-optionals. Your init is throwable, so if something doesn't decode from json as you'd expect an error is thrown for you to handle. You can then just filter that model out etc.
* Some force unwraps I couldn't clean up because I don't know what default to return for an Rx `Observable`. In ReactiveSwift you can for example return an empty `SignalProducer` (cold signal) which completes immediately without sending values. 
* There's captured `self` in a lot of places, and this will result in a retain cycles (memory leaks). I didn't have time to clean these up. See below though.

And a few notes, from a swift guy to an android guy 😄 :

* Anytime you see a `!` (force unwrap) or an `as!` (force cast) that's a crash waiting to happen. Always favour non-optionals where possible, or `?` to safely unwrap. There's a bunch of operators to help you here:
  * [Optional Chaining](https://developer.apple.com/library/content/documentation/Swift/Conceptual/Swift_Programming_Language/OptionalChaining.html)
  * [Nil Coalescing](https://developer.apple.com/library/content/documentation/Swift/Conceptual/Swift_Programming_Language/BasicOperators.html) (half way down)
  * `if let` / `guard let`
  * Probably other stuff I'm forgetting :)
* Some `!` are legit. Ie where you know there will always be a value but it's simpler to do it this way than fight the compiler. Or when using storyboards with `@IBOutlet` etc. Also where you actually *do* want the app to crash if something is nil or wrong type. 
* Watch out for captured `self`. Everytime you reference `self` in an anonymous closure it captures. You need to weakify `self` to break this. See [ARC](https://developer.apple.com/library/content/documentation/Swift/Conceptual/Swift_Programming_Language/AutomaticReferenceCounting.html) (about 2/3 way down) 
* Swift is really opinionated when it comes to naming and casing. See [Swift API Design Guidelines](https://swift.org/documentation/api-design-guidelines/). So the conventions are pretty different between swift and java (ie with enums).